### PR TITLE
Automatic discount when min order

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -85,14 +85,16 @@
 
 ### Story 5
 
-- [] Can ASSIGN a discount to an item. i.e. 'M&Ms' -> '5% off 5'
-- [] Discount ONLY applies when item quantity is met with the SAME item.
-- [] Discount DOESN'T applies when items are DIFFERENT.
+- [] When a user adds enough value or quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.
+  - [] Discount ONLY applies when item quantity is met with the SAME item.
+  - [] When there is a conflict between two discounts, the greater of the two will be applied
+  - [] Discount DOESN'T applies when items are DIFFERENT.
 
 ### Story 6
 
-- [] When there is a conflict between two discounts, the greater of the two will be applied
+- [] Discount shows in the cart page
+- [] Final discounted prices should appear on the orders show page
 
 ### Story 7
 
-- [] Final discounted prices should appear on the orders show page
+- [] A bulk discount from one merchant will only affect items from that merchant in the cart.

--- a/TASKS.md
+++ b/TASKS.md
@@ -85,10 +85,10 @@
 
 ### Story 5
 
-- [] When a user adds enough value or quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.
-  - [] Discount ONLY applies when item quantity is met with the SAME item.
-  - [] When there is a conflict between two discounts, the greater of the two will be applied
-  - [] Discount DOESN'T applies when items are DIFFERENT.
+- [x] When a user adds enough value or quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.
+  - [x] Discount ONLY applies when item quantity is met with the SAME item.
+  - [x] When there is a conflict between two discounts, the greater of the two will be applied
+  - [x] Discount DOESN'T applies when items are DIFFERENT.
 
 ### Story 6
 
@@ -98,3 +98,73 @@
 ### Story 7
 
 - [] A bulk discount from one merchant will only affect items from that merchant in the cart.
+
+
+
+## Notes:
+
+Cart:
+
+- I can see the Merchant
+- I can see the Item
+- @contents shows me the 'id' and the quantity of it in the cart
+- I can access the discounts:
+  Item.find(item_id).merchant.discounts
+- I can obtain a discount value:
+  discount_value = Item.find(item_id).merchant.discounts.first.discount_percentage
+
+
+  1. Is there a discount for this item?
+  2. #count_of(item_id) == discount.minimum_quantity?
+  3. subtotal_of(item_id) * discount_value
+
+  Methods:
+
+  - #check_for_item_discounts(item_id)
+      `Item.find(item_id).merchant.discounts`
+  - #match_by_discount_criteria(item_id)
+
+    discounts = Item.find(item_id).merchant.discounts
+    #=> returns collection of associations that act like an array
+
+    discounts.select(:minimum_quantity).find_by(minimum_quantity: @contents[item_id.to_s]).minimum_quantity
+    #=> returns an integer
+
+
+  - #discount_value(item_id)
+  ```
+  def discount_value(item_id)
+    if match_by_discount_criteria(item_id)
+      match_by_discount_criteria(item_id).discount_percentage
+    end
+  end
+  ```
+
+  All of this materializes inside #subtotal_of(item_id)
+
+  price = unless discount_value(item_id).nil?
+    Item.find(item_id).price * discount_value(item_id)
+    else
+    Item.find(item_id).price
+  end
+
+Issue!
+when the discount criteria is not met then
+match_by_discount_criteria(item_id) returns
+nil.
+
+matcher:
+if not nil and it matches then retun the discount object, else return a string "no discount"
+
+discount value: 
+if matcher = "no discount"
+return 1
+else return 
+extracted value
+end
+
+
+Issue! 2
+
+
+discounts.select(:minimum_quantity).find_by('minimum_quantity <= ?', total).minimum_quantity

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -37,10 +37,33 @@ class Cart
   end
 
   def subtotal_of(item_id)
-    @contents[item_id.to_s] * Item.find(item_id).price
+    price = if discount_value(item_id) != 0
+      Item.find(item_id).price * discount_value(item_id)
+    else
+      Item.find(item_id).price
+    end
+    @contents[item_id.to_s] * price
   end
 
   def limit_reached?(item_id)
     count_of(item_id) == Item.find(item_id).inventory
+  end
+
+  def check_for_item_discounts(item_id)
+    Item.find(item_id).merchant.discounts
+  end
+
+  def match_by_discount_criteria(item_id)
+    discounts = check_for_item_discounts(item_id)
+    total = @contents[item_id.to_s]
+    if total >= discounts.select(:minimum_quantity).find_by(minimum_quantity: total).minimum_quantity
+      discounts.find_by(minimum_quantity: total)
+    end
+  end
+
+  def discount_value(item_id)
+    if match_by_discount_criteria(item_id)
+      match_by_discount_criteria(item_id).discount_percentage
+    end
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -37,11 +37,7 @@ class Cart
   end
 
   def subtotal_of(item_id)
-    price = if discount_value(item_id) != 0
-      Item.find(item_id).price * discount_value(item_id)
-    else
-      Item.find(item_id).price
-    end
+    price = Item.find(item_id).price * discount_value(item_id)
     @contents[item_id.to_s] * price
   end
 
@@ -56,13 +52,17 @@ class Cart
   def match_by_discount_criteria(item_id)
     discounts = check_for_item_discounts(item_id)
     total = @contents[item_id.to_s]
-    if total >= discounts.select(:minimum_quantity).find_by(minimum_quantity: total).minimum_quantity
+    if discounts.find_by(minimum_quantity: total) != nil && total >= discounts.select(:minimum_quantity).find_by(minimum_quantity: total).minimum_quantity
       discounts.find_by(minimum_quantity: total)
+    else
+      "No discount available"
     end
   end
 
   def discount_value(item_id)
-    if match_by_discount_criteria(item_id)
+    if match_by_discount_criteria(item_id) == "No discount available"
+      1
+    else 
       match_by_discount_criteria(item_id).discount_percentage
     end
   end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -52,8 +52,8 @@ class Cart
   def match_by_discount_criteria(item_id)
     discounts = check_for_item_discounts(item_id)
     total = @contents[item_id.to_s]
-    if discounts.find_by(minimum_quantity: total) != nil && total >= discounts.select(:minimum_quantity).find_by(minimum_quantity: total).minimum_quantity
-      discounts.find_by(minimum_quantity: total)
+    if discounts.find_by('minimum_quantity <= ?', total) != nil && total >= discounts.where('minimum_quantity <= ?', total).order(discount_percentage: :asc).pluck(:discount_percentage).first
+    discounts.where('minimum_quantity <= ?', total).order(discount_percentage: :asc).first
     else
       "No discount available"
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,24 +6,24 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+OrderItem.destroy_all
 Item.destroy_all
 Order.destroy_all
-OrderItem.destroy_all
 User.destroy_all
 Merchant.destroy_all
 
 
 ##=================== Merchants 
-@megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
-@brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
-@sal = Merchant.create!(name: 'Sals Salamanders', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+@merchant_1 = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+@merchant_2 = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+
+@m_1_user = @merchant_1.users.create(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'megan@example.com', password: 'securepassword')
+@m_2_user = @merchant_2.users.create(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'megan@example.com', password: 'securepassword')
 
 ##=================== Items 
-@ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
-@giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
-@hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
-
-
+@ogre = @merchant_1.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+@giant = @merchant_1.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+@hippo = @merchant_2.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
 
 ##=================== Users
 @user_1 = User.create!(name: 'Tom', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'tom@gmail.com', password: 'securepassword')

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -96,8 +96,14 @@ RSpec.describe Cart do
       end
       expect(@cart.count_of(@ogre.id)).to eq(5)
       expect(@cart.subtotal_of(@ogre.id)).to eq(95)
+
+      3.times do
+        @cart.add_item(@ogre.id.to_s)
+      end
+      expect(@cart.count_of(@ogre.id)).to eq(8)
+      expect(@cart.subtotal_of(@ogre.id)).to eq(152)
       
-      5.times do
+      2.times do
         @cart.add_item(@ogre.id.to_s)
       end
       expect(@cart.count_of(@ogre.id)).to eq(10)

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -88,14 +88,20 @@ RSpec.describe Cart do
     end
 
     it "#subtotal_of" do
-      expect(@cart.subtotal_of(@ogre.id)).to eq(20)
       expect(@cart.count_of(@ogre.id)).to eq(1)
+      expect(@cart.subtotal_of(@ogre.id)).to eq(20)
       
       4.times do
         @cart.add_item(@ogre.id.to_s)
       end
       expect(@cart.count_of(@ogre.id)).to eq(5)
-      expect(@cart.subtotal_of(@ogre.id)).to eq(95)   
+      expect(@cart.subtotal_of(@ogre.id)).to eq(95)
+      
+      5.times do
+        @cart.add_item(@ogre.id.to_s)
+      end
+      expect(@cart.count_of(@ogre.id)).to eq(10)
+      expect(@cart.subtotal_of(@ogre.id)).to eq(180)   
     end
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -52,11 +52,6 @@ RSpec.describe Cart do
       expect(@cart.count_of(@giant.id)).to eq(2)
     end
 
-    # it '.subtotal_of()' do
-      # expect(@cart.subtotal_of(@ogre.id)).to eq(20)
-      # expect(@cart.subtotal_of(@giant.id)).to eq(100)
-    # end
-
     it '.limit_reached?()' do
       expect(@cart.limit_reached?(@ogre.id)).to eq(false)
       expect(@cart.limit_reached?(@giant.id)).to eq(true)
@@ -92,8 +87,7 @@ RSpec.describe Cart do
       expect(@cart.discount_value(@ogre.id)).to eq(0.95)   
     end
 
-    it ".subtotal_of()" do
-      # binding.pry
+    it "#subtotal_of" do
       expect(@cart.subtotal_of(@ogre.id)).to eq(20)
       expect(@cart.count_of(@ogre.id)).to eq(1)
       

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Cart do
       @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
       @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 2 )
       @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+
+      @discount_1 = @megan.discounts.create(name: "5% off 5", discount_percentage: 0.95, minimum_quantity: 5)
+      @discount_2 = @megan.discounts.create(name: "10% off 10", discount_percentage: 0.90, minimum_quantity: 10)
+
       @cart = Cart.new({
         @ogre.id.to_s => 1,
         @giant.id.to_s => 2
@@ -48,10 +52,10 @@ RSpec.describe Cart do
       expect(@cart.count_of(@giant.id)).to eq(2)
     end
 
-    it '.subtotal_of()' do
-      expect(@cart.subtotal_of(@ogre.id)).to eq(20)
-      expect(@cart.subtotal_of(@giant.id)).to eq(100)
-    end
+    # it '.subtotal_of()' do
+      # expect(@cart.subtotal_of(@ogre.id)).to eq(20)
+      # expect(@cart.subtotal_of(@giant.id)).to eq(100)
+    # end
 
     it '.limit_reached?()' do
       expect(@cart.limit_reached?(@ogre.id)).to eq(false)
@@ -62,6 +66,42 @@ RSpec.describe Cart do
       @cart.less_item(@giant.id.to_s)
 
       expect(@cart.count_of(@giant.id)).to eq(1)
+    end
+
+    it "#check_for_item_discounts" do
+      4.times do
+        @cart.add_item(@ogre.id.to_s)
+      end
+      expect(@cart.count_of(@ogre.id)).to eq(5)
+      expect(@cart.check_for_item_discounts(@ogre.id)).to eq([@discount_1, @discount_2])   
+    end
+
+    it "#match_by_discount_criteria" do
+      4.times do
+        @cart.add_item(@ogre.id.to_s)
+      end
+      expect(@cart.count_of(@ogre.id)).to eq(5)
+      expect(@cart.match_by_discount_criteria(@ogre.id)).to eq(@discount_1)   
+    end
+
+    it "#discount_value" do
+      4.times do
+        @cart.add_item(@ogre.id.to_s)
+      end
+      expect(@cart.count_of(@ogre.id)).to eq(5)
+      expect(@cart.discount_value(@ogre.id)).to eq(0.95)   
+    end
+
+    it ".subtotal_of()" do
+      # binding.pry
+      expect(@cart.subtotal_of(@ogre.id)).to eq(20)
+      expect(@cart.count_of(@ogre.id)).to eq(1)
+      
+      4.times do
+        @cart.add_item(@ogre.id.to_s)
+      end
+      expect(@cart.count_of(@ogre.id)).to eq(5)
+      expect(@cart.subtotal_of(@ogre.id)).to eq(95)   
     end
   end
 end


### PR DESCRIPTION
### Story 5

- [x] When a user adds enough value or quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.
  - [x] Discount ONLY applies when item quantity is met with the SAME item.
  - [x] When there is a conflict between two discounts, the greater of the two will be applied
  - [x] Discount DOESN'T applies when items are DIFFERENT.

Created the following cart model test and methods

* #check_for_item_discounts(item_id)
* #match_by_discount_criteria(item_id)
* #discount_value(item_id)

Had to refactor the item/discount matching method to address edge cases.
All tests pass now